### PR TITLE
update for pygls 0.10

### DIFF
--- a/lark_language_server/error_reporting.py
+++ b/lark_language_server/error_reporting.py
@@ -1,7 +1,7 @@
 from typing import List, Union
 import logging
 from lark import UnexpectedToken
-from pygls.types import (Diagnostic, Range, Position)
+from pygls.lsp import (Diagnostic, Range, Position)
 
 from .lark_grammar import lark_grammar_parser
 

--- a/lark_language_server/server.py
+++ b/lark_language_server/server.py
@@ -1,10 +1,11 @@
 import typing as t
-from pygls.features import (COMPLETION, TEXT_DOCUMENT_DID_CHANGE,
-                            TEXT_DOCUMENT_DID_CLOSE, TEXT_DOCUMENT_DID_OPEN)
+from pygls.lsp.methods import (COMPLETION, TEXT_DOCUMENT_DID_CHANGE,
+                               TEXT_DOCUMENT_DID_CLOSE, TEXT_DOCUMENT_DID_OPEN)
 from pygls.server import LanguageServer
-from pygls.types import (CompletionItem, CompletionList, CompletionParams,
-                         DidChangeTextDocumentParams,
-                         DidCloseTextDocumentParams, DidOpenTextDocumentParams)
+from pygls.lsp import (CompletionItem, CompletionList, CompletionParams,
+                       CompletionOptions,
+                       DidChangeTextDocumentParams,
+                       DidCloseTextDocumentParams, DidOpenTextDocumentParams)
 
 from .error_reporting import get_diagnostics
 
@@ -25,12 +26,12 @@ def _validate(ls: LarkLanguageServer, params: DidChangeTextDocumentParams):
     ls.publish_diagnostics(text_doc.uri, get_diagnostics(text_doc.source))
 
 
-@lark_server.feature(COMPLETION, trigger_characters=[','])
+@lark_server.feature(COMPLETION, CompletionOptions(trigger_characters=[',']))
 def completions(ls: LarkLanguageServer, params: CompletionParams = None):
     """Returns completion items."""
     ls.show_message_log('completion called @ {}'.format(params.position))
     items: t.List[CompletionItem] = []
-    return CompletionList(False, items)
+    return CompletionList(is_incomplete=False, items=items)
 
 
 @lark_server.feature(TEXT_DOCUMENT_DID_CHANGE)

--- a/setup.py
+++ b/setup.py
@@ -4,11 +4,16 @@ setup(
     name="lark-language-server",
     version="0.1.0",
     packages=['lark_language_server'],
-    install_requires=["pygls==0.9.0", "lark-parser"],
+    install_requires=["pygls>=0.10.2,<0.11", "lark-parser"],
     python_requires=">=3.7",
     extras_require={"test": ["pytest"]},
     package_data={},
     description="Language Server for Lark Grammar",
     license="MIT",
     url="https://github.com/lark-parser/lark-language-server",
+    entry_points={
+        "console_scripts": [
+            "lark-language-server = lark_language_server.__main__:main"
+        ]
+    }
 )

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,6 +1,6 @@
 from unittest.mock import Mock
-from pygls.types import (CompletionParams, Position,
-                         TextDocumentIdentifier)
+from pygls.lsp import (CompletionParams, Position,
+                       TextDocumentIdentifier)
 from pygls.workspace import Document, Workspace
 
 
@@ -10,22 +10,23 @@ from lark_language_server import server
 class FakeServer():
     def __init__(self):
         self.workspace = Workspace('', None)
+        self.show_message_log = Mock()
+        self.workspace.get_document = Mock(return_value=fake_document)
 
 
 fake_document_uri = 'file://fake_doc.txt'
 fake_document_content = 'text'
 fake_document = Document(fake_document_uri, fake_document_content)
 
-
 fake_server = FakeServer()
-fake_server.show_message_log = Mock()
-fake_server.workspace.get_document = Mock(return_value=fake_document)
 
 
 def test_completions():
     """An example test which does very little"""
     completion_list = server.completions(
         fake_server,
-        CompletionParams(TextDocumentIdentifier('file://fake_doc.txt'), Position(0, 2), None))
+        CompletionParams(
+            text_document=TextDocumentIdentifier(uri='file://fake_doc.txt'),
+            position=Position(line=0, character=2)))
     # test the list is empty for now
     assert completion_list.items == []


### PR DESCRIPTION
Hi lovely larkers! I was just thinking to myself, heck, it would be great if there was an example of using lark and pygls for a language server, and lo: it doesn't get much better than a language server that will help me _write_ my grammar!

This PR: 
- updates to the [pygls 0.10 API](https://github.com/openlawlibrary/pygls/issues/151). 
  - Since 0.8, it's 
    - fixed a bunch of bugs 
    - dropped `psutil`
    - uses `pydantic`, replacing a lot of hand-made validation and types
- adds a `lark-language-server` console script so that it's a touch easier to launch.
- moves some mocks into the test server constructor to appease mypy

Longer con: I tinker with [jupyterlab-lsp](https://pypi.org/project/jupyterlab-lsp/), and see a lot of benefit to being able to quickly (and potentially interactively) gin up a language server and start using it immediately from basically one python and one lark file making use of a "construction set" that would offer boilerplate around basic LSP tasks... the dream would be:

```py
class FooLanguageServer(LarkuageServer):
    CONFIGURATION_SECTION = 'FooLanguageServer'
    GRAMMER = Lark(""""start:""", ...)
```

...and it's off to the races for diagnostics, basic hover, built-ins completion, symbol tree, etc. with relatively easy access to _your_ token types for making nice messages, etc. Food for thought!